### PR TITLE
Recurring events support

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,10 +4,12 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-ics = "*"
 requests = "*"
 pyyaml = "*"
 schedule = "*"
+icalendar = "*"
+recurring-ical-events = "*"
+pytz = "*"
 
 [dev-packages]
 flake8 = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9f09651650efdbf8ed953e59e0c155e2c035b1db8585669998a7afcf2448239d"
+            "sha256": "4ff12937b7c52e2a5bf5b9457b309c30635c1a0249e4c18cc085bd9c07899b3e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,22 +16,6 @@
         ]
     },
     "default": {
-        "arrow": {
-            "hashes": [
-                "sha256:3934b30ca1b9f292376d9db15b19446088d12ec58629bc3f0da28fd55fb633a1",
-                "sha256:5a49ab92e3b7b71d96cd6bfcc4df14efefc9dfa96ea19045815914a6ab6b1fe2"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.2.3"
-        },
-        "attrs": {
-            "hashes": [
-                "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
-                "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==22.1.0"
-        },
         "certifi": {
             "hashes": [
                 "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",
@@ -48,14 +32,13 @@
             "markers": "python_version >= '3.6'",
             "version": "==2.1.1"
         },
-        "ics": {
+        "icalendar": {
             "hashes": [
-                "sha256:5fcf4d29ec6e7dfcb84120abd617bbba632eb77b097722b7df70e48dbcf26103",
-                "sha256:6743539bca10391635249b87d74fcd1094af20b82098bebf7c7521df91209f05",
-                "sha256:da352bdf8418619dc93611e6d251f3cefbb42664777f6e00b580a722098124b7"
+                "sha256:35faeae20e58d0fe26e33c04bbfd08b424192d61ae3e1da1d7611ba06ab33570",
+                "sha256:41f2f450707a503365a81c22954be4053779994c8ff01fc11bf4ce33a724092e"
             ],
             "index": "pypi",
-            "version": "==0.7.2"
+            "version": "==5.0.1"
         },
         "idna": {
             "hashes": [
@@ -72,6 +55,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.2"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:222439474e9c98fced559f1709d89e6c9cbf8d79c794ff3eb9f8800064291427",
+                "sha256:e89512406b793ca39f5971bc999cc538ce125c0e51c27941bef4568b460095e2"
+            ],
+            "index": "pypi",
+            "version": "==2022.6"
         },
         "pyyaml": {
             "hashes": [
@@ -119,6 +110,14 @@
             "index": "pypi",
             "version": "==6.0"
         },
+        "recurring-ical-events": {
+            "hashes": [
+                "sha256:0aed6a5965c719e50aa2e5f6be896688cdb2c2da7087fae928ad4ac05ff0785f",
+                "sha256:c2dd86ccbb03891ce17f353f79d0a10779199270dbe3cb63b4f8fe387360dea5"
+            ],
+            "index": "pypi",
+            "version": "==1.0.3b0"
+        },
         "requests": {
             "hashes": [
                 "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
@@ -143,14 +142,6 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
-        "tatsu": {
-            "hashes": [
-                "sha256:0a836692e67247cad9f251e083b045b13345cc715e69a7fbc16522beaa0f2163",
-                "sha256:571ecbcdf33b7828c05e5cd95a8e8ad06af111c2c83a6a245be4d8f7c43de7bb"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==5.8.3"
-        },
         "urllib3": {
             "hashes": [
                 "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
@@ -158,6 +149,13 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
             "version": "==1.26.12"
+        },
+        "x-wr-timezone": {
+            "hashes": [
+                "sha256:c05cb34b9b58a4607a788db086dcae5766728e4b94e0672870dc5593a6e13fe6",
+                "sha256:e438b27b96635f5f712a4fb5dda4c82597a53a412fe834c9fe8409fddb3fc2b1"
+            ],
+            "version": "==0.0.5"
         }
     },
     "develop": {

--- a/eventsbot/discord.py
+++ b/eventsbot/discord.py
@@ -31,18 +31,18 @@ class Event:
     metadata: dict[str, str]
     privacy_level: int = 2
 
-    def __eq__(self, other) -> bool:    
-        if not isinstance(other, Event):    
-            # don't attempt to compare against unrelated types    
-            return NotImplemented    
-            
-        return (    
-            self.name == other.name    
-            and self.start_time == other.start_time    
-            and self.end_time == other.end_time    
-            and self.metadata == other.metadata    
-            and self.privacy_level == other.privacy_level    
-        )    
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, Event):
+            # don't attempt to compare against unrelated types
+            return NotImplemented
+
+        return (
+            self.name == other.name
+            and self.start_time == other.start_time
+            and self.end_time == other.end_time
+            and self.metadata == other.metadata
+            and self.privacy_level == other.privacy_level
+        )
 
 
 class DiscordGuildError(Exception):

--- a/eventsbot/eventsbot.py
+++ b/eventsbot/eventsbot.py
@@ -7,6 +7,7 @@ import signal
 import sys
 import time
 from enum import Enum, auto
+from typing import Any
 
 import arrow
 
@@ -214,6 +215,7 @@ def get_from_env(variable: str, default: None | str = None) -> None | bool | str
     if variable not in os.environ:
         return default
 
+    value = None
     if variable in os.environ:
         value = os.environ.get(variable)
         if value is not None and re.search(r"^[Y|y]es|YES|[T|t]rue|TRUE|[O|o]n|ON|1$", value):
@@ -226,7 +228,7 @@ def get_from_env(variable: str, default: None | str = None) -> None | bool | str
 def setup_from_env() -> dict:
     """Setup the bot using environment variables."""
 
-    config: dict = {"discord": {"message": {}}}
+    config: dict[str, Any] = {"discord": {"message": {}}}
     root_variables = [
         ("default_location", DEFAULT_EVENT_LOCATION),
         ("calendar_url", None),


### PR DESCRIPTION
ics-py does not (yet) support recurring events (see: ics-py/ics-py#14)

* Replaced `ics-py` by `icalendar` + `recurring-ical-events`
* Added Discord rate limiting support (API calls will be retried after the delay given in HTTP 429 response)